### PR TITLE
Add:issue#64の機能を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :init_team, if: :user_signed_in?
   before_action :set_working_team, if: :user_signed_in?
+  before_action :set_current_user
 
   def change_keep_team(user, current_team)
     user.keep_team_id = current_team.id
@@ -15,5 +16,9 @@ class ApplicationController < ActionController::Base
 
   def init_team
     current_user.assigns.create!(team_id: Team.first.id) if current_user.teams.blank?
+  end
+
+  def set_current_user
+    @current_user = User.find_by(id:  session[:user_id])
   end
 end

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -26,15 +26,17 @@ class AssignsController < ApplicationController
   end
 
   def assign_destroy(assign, assigned_user)
-    if assigned_user == assign.team.owner
-      I18n.t('views.messages.cannot_delete_the_leader')
-    elsif Assign.where(user_id: assigned_user.id).count == 1
-      I18n.t('views.messages.cannot_delete_only_a_member')
-    elsif assign.destroy
-      set_next_team(assign, assigned_user)
-      I18n.t('views.messages.delete_member')
-    else
-      I18n.t('views.messages.cannot_delete_member_4_some_reason')
+    if assign.team.isOwned?(current_user) or assigned_user == @current_user
+      if assigned_user == assign.team.owner
+        I18n.t('views.messages.cannot_delete_the_leader')
+      elsif Assign.where(user_id: assigned_user.id).count == 1
+        I18n.t('views.messages.cannot_delete_only_a_member')
+      elsif assign.destroy
+        set_next_team(assign, assigned_user)
+        I18n.t('views.messages.delete_member')
+      else
+        I18n.t('views.messages.cannot_delete_member_4_some_reason')
+      end
     end
   end
   

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,7 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_team, only: %i[show edit update destroy]
+  before_action :edit_owner, only: %i[edit]
 
   def index
     @teams = Team.all
@@ -55,5 +56,11 @@ class TeamsController < ApplicationController
 
   def team_params
     params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
+  end
+
+  def edit_owner
+    unless @team.isOwned?(current_user)
+      redirect_to@team
+    end
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -15,4 +15,9 @@ class Team < ApplicationRecord
   def invite_member(user)
     assigns.create(user: user)
   end
+
+  def isOwned?(user)
+    return false if user.nil?
+    return self.owner_id == user.id
+  end
 end


### PR DESCRIPTION
feature/issues-#64

以下の機能を追加
Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
TeamのeditはTeamのリーダー（オーナー）のみができるようにすること